### PR TITLE
Comparison should be case in-sensitive

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -38,8 +38,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 
 func (p *Plugin) WordIsBad(word string) bool {
-	word := strings.ToLower(word)
-	_, ok := p.badWords[word]
+	_, ok := p.badWords[strings.ToLower(word)]
 	return ok
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,7 +22,7 @@ func main() {
 
 func (p *Plugin) OnActivate() error {
 	p.badWords = make(map[string]bool, len(badWords))
-	word := string.ToLower(word)
+	word := strings.ToLower(word)
 	for _, word := range badWords {
 		p.badWords[word] = true
 	}
@@ -38,7 +38,7 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 }
 
 func (p *Plugin) WordIsBad(word string) bool {
-	word := string.ToLower(word)
+	word := strings.ToLower(word)
 	_, ok := p.badWords[word]
 	return ok
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -22,9 +22,8 @@ func main() {
 
 func (p *Plugin) OnActivate() error {
 	p.badWords = make(map[string]bool, len(badWords))
-	word := strings.ToLower(word)
 	for _, word := range badWords {
-		p.badWords[word] = true
+		p.badWords[strings.ToLower(word)] = true
 	}
 
 	return nil


### PR DESCRIPTION
All words to be filtered should be lower-case, regardless of how entered.  Word to be compared should be lower-case, regardless of how entered.