### PR TITLE
[GH-25] Adds option to disable filtering for bot messages

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -17,6 +17,12 @@
   "settings_schema": {
     "settings": [
       {
+        "key": "ExcludeBots",
+        "display_name": "Exclude Bots",
+        "type": "bool",
+        "help_text": "If set the plugin will exclude bot messages from being checked."
+      },
+      {
         "key": "RejectPosts",
         "display_name": "Reject Posts",
         "type": "bool",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -22,6 +22,7 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
+	ExcludeBots     bool
 	RejectPosts     bool
 	CensorCharacter string
 	BadWordsList    string

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -29,13 +29,19 @@ type Plugin struct {
 }
 
 func (p *Plugin) FilterPost(post *model.Post) (*model.Post, string) {
+	configuration := p.getConfiguration()
+	_, fromBot := post.GetProps()["from_bot"]
+
+	if configuration.ExcludeBots && fromBot {
+		return post, ""
+	}
+
 	postMessageWithoutAccents := removeAccents(post.Message)
 
 	if !p.badWordsRegex.MatchString(postMessageWithoutAccents) {
 		return post, ""
 	}
 
-	configuration := p.getConfiguration()
 	detectedBadWords := p.badWordsRegex.FindAllString(postMessageWithoutAccents, -1)
 
 	if configuration.RejectPosts {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -16,6 +16,7 @@ func TestMessageWillBePosted(t *testing.T) {
 			CensorCharacter: "*",
 			RejectPosts:     false,
 			BadWordsList:    "def ghi,abc",
+			ExcludeBots:     true,
 		},
 	}
 	p.badWordsRegex = regexp.MustCompile(wordListToRegex(p.getConfiguration().BadWordsList))
@@ -79,6 +80,21 @@ func TestMessageWillBePosted(t *testing.T) {
 		out := &model.Post{
 			Message: "helloabcworld helloabc abchello",
 		}
+
+		rpost, s := p.MessageWillBePosted(&plugin.Context{}, in)
+		assert.Empty(t, s)
+		assert.Equal(t, out, rpost)
+	})
+
+	t.Run("bot messages shouldn't be blocked", func(t *testing.T) {
+		in := &model.Post{
+			Message: "abc",
+		}
+		in.AddProp("from_bot", "true")
+		out := &model.Post{
+			Message: "abc",
+		}
+		out.AddProp("from_bot", "true")
 
 		rpost, s := p.MessageWillBePosted(&plugin.Context{}, in)
 		assert.Empty(t, s)


### PR DESCRIPTION
#### Summary
This PR adds an option to disable filtering for bot messages. Thus bots can still be able to use bad words in their messages.
#### Ticket Link
Fixes #25 